### PR TITLE
Organize tab views into feature folders

### DIFF
--- a/survivus/ContentView.swift
+++ b/survivus/ContentView.swift
@@ -1,289 +1,4 @@
-
-// Survivus – SwiftUI starter
-// Single-file playground-style SwiftUI app scaffold
-// Tabs: Results • Picks • Table
-// Includes: data models, scoring engine, simple in‑memory store, mock data, and basic UI
-// You can later swap Storage to Firebase/CloudKit.
-
 import SwiftUI
-
-// MARK: - UI
-
-struct SurvivusApp: App {
-    @StateObject private var app = AppState()
-
-    var body: some Scene {
-        WindowGroup {
-            TabView {
-                ResultsView()
-                    .environmentObject(app)
-                    .tabItem { Label("Results", systemImage: "list.bullet.rectangle") }
-                PicksView()
-                    .environmentObject(app)
-                    .tabItem { Label("Picks", systemImage: "checkmark.square") }
-                TableView()
-                    .environmentObject(app)
-                    .tabItem { Label("Table", systemImage: "tablecells") }
-            }
-        }
-    }
-}
-
-// MARK: - Results Tab
-
-struct ResultsView: View {
-    @EnvironmentObject var app: AppState
-
-    var body: some View {
-        NavigationStack {
-            List(app.store.config.episodes) { ep in
-                let result = app.store.resultsByEpisode[ep.id]
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack {
-                        Text(ep.title).font(.headline)
-                        if ep.isMergeEpisode { Text("MERGE").font(.caption2).padding(4).background(.yellow.opacity(0.3)).clipShape(RoundedRectangle(cornerRadius: 6)) }
-                        Spacer()
-                        Text(ep.airDate, style: .date).foregroundStyle(.secondary)
-                    }
-                    if let r = result {
-                        if !r.immunityWinners.isEmpty {
-                            Text("Immunity: " + r.immunityWinners.compactMap { id in app.store.config.contestants.first { $0.id == id }?.name }.joined(separator: ", "))
-                        }
-                        if !r.votedOut.isEmpty {
-                            Text("Voted out: " + r.votedOut.compactMap { id in app.store.config.contestants.first { $0.id == id }?.name }.joined(separator: ", "))
-                        }
-                    } else {
-                        Text("No result yet").foregroundStyle(.secondary)
-                    }
-                }
-            }
-            .navigationTitle("Results")
-        }
-    }
-}
-
-// MARK: - Picks Tab
-
-struct PicksView: View {
-    @EnvironmentObject var app: AppState
-    @State private var selectedEpisode: Episode?
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                Section("Season Picks") {
-                    MergePickEditor()
-                    FinalThreePickEditor()
-                    WinnerPickEditor()
-                }
-
-                Section("Weekly Picks") {
-                    Picker("Episode", selection: Binding(
-                        get: { selectedEpisode?.id ?? app.store.config.episodes.first?.id ?? 1 },
-                        set: { newId in selectedEpisode = app.store.config.episodes.first(where: { $0.id == newId }) }
-                    )) {
-                        ForEach(app.store.config.episodes) { ep in
-                            Text(ep.title).tag(ep.id)
-                        }
-                    }
-                    if let ep = app.store.config.episodes.first(where: { $0.id == (selectedEpisode?.id ?? app.store.config.episodes.first!.id) }) {
-                        WeeklyPickEditor(episode: ep)
-                    }
-                }
-            }
-            .onAppear { if selectedEpisode == nil { selectedEpisode = app.store.config.episodes.first } }
-            .navigationTitle("Picks")
-        }
-    }
-}
-
-// MARK: - Merge Picks Editor
-
-struct MergePickEditor: View {
-    @EnvironmentObject var app: AppState
-
-    var body: some View {
-        let cfg = app.store.config
-        let userId = app.currentUserId
-        let disabled = picksLocked(for: cfg.episodes.first)
-        VStack(alignment: .leading, spacing: 8) {
-            HStack { Text("Who Will Make the Merge (3)").font(.headline); if disabled { LockPill() } }
-            LimitedMultiSelect(
-                all: cfg.contestants,
-                selection: Binding(
-                    get: { app.store.seasonPicks[userId]?.mergePicks ?? [] },
-                    set: { new in app.store.seasonPicks[userId]?.mergePicks = Set(new.prefix(3)) }
-                ),
-                max: 3,
-                disabled: disabled
-            )
-        }
-    }
-}
-
-// MARK: - Final Three Picks Editor
-
-struct FinalThreePickEditor: View {
-    @EnvironmentObject var app: AppState
-
-    var body: some View {
-        let cfg = app.store.config
-        let userId = app.currentUserId
-        // Enable after merge episode
-        let afterMerge = cfg.episodes.contains(where: { $0.isMergeEpisode })
-        VStack(alignment: .leading, spacing: 8) {
-            HStack { Text("Final Three Picks (3)").font(.headline); if !afterMerge { Text("(Available after merge)").foregroundStyle(.secondary) } }
-            LimitedMultiSelect(
-                all: cfg.contestants,
-                selection: Binding(
-                    get: { app.store.seasonPicks[userId]?.finalThreePicks ?? [] },
-                    set: { new in app.store.seasonPicks[userId]?.finalThreePicks = Set(new.prefix(3)) }
-                ),
-                max: 3,
-                disabled: !afterMerge
-            )
-        }
-    }
-}
-
-// MARK: - Winner Pick Editor
-
-struct WinnerPickEditor: View {
-    @EnvironmentObject var app: AppState
-
-    var body: some View {
-        let cfg = app.store.config
-        let userId = app.currentUserId
-        // Enable after Final Three determined (simplified: after last episode - 1)
-        let enable = cfg.episodes.count >= 2
-        VStack(alignment: .leading, spacing: 8) {
-            HStack { Text("Sole Survivor (1)").font(.headline); if !enable { Text("(Available after Final Three)").foregroundStyle(.secondary) } }
-            Picker("Winner", selection: Binding(
-                get: { app.store.seasonPicks[userId]?.winnerPick ?? "" },
-                set: { app.store.seasonPicks[userId]?.winnerPick = $0.isEmpty ? nil : $0 }
-            )) {
-                Text("—").tag("")
-                ForEach(app.store.config.contestants) { c in Text(c.name).tag(c.id) }
-            }
-            .disabled(!enable)
-        }
-    }
-}
-
-// MARK: - Weekly Picks Editor
-
-struct WeeklyPickEditor: View {
-    @EnvironmentObject var app: AppState
-    let episode: Episode
-
-    var body: some View {
-        let cfg = app.store.config
-        let userId = app.currentUserId
-        let phase = app.scoring.phase(for: episode)
-        let caps = (phase == .preMerge) ? cfg.weeklyPickCapsPreMerge : cfg.weeklyPickCapsPostMerge
-        let locked = picksLocked(for: episode)
-
-        @State var picks = app.store.picks(for: userId, episodeId: episode.id)
-
-        VStack(alignment: .leading, spacing: 16) {
-            if locked { LockPill(text: "Locked for \(episode.title)") }
-
-            Group {
-                Text("Who Will Remain (\(caps.remain ?? 3))").font(.headline)
-                LimitedMultiSelect(all: cfg.contestants, selection: Binding(
-                    get: { picks.remain },
-                    set: { picks.remain = Set($0.prefix(caps.remain ?? 3)) }
-                ), max: caps.remain ?? 3, disabled: locked)
-            }
-
-            Group {
-                Text("Who Will be Voted Out (\(caps.votedOut ?? 3))").font(.headline)
-                LimitedMultiSelect(all: cfg.contestants, selection: Binding(
-                    get: { picks.votedOut },
-                    set: { picks.votedOut = Set($0.prefix(caps.votedOut ?? 3)) }
-                ), max: caps.votedOut ?? 3, disabled: locked)
-            }
-
-            Group {
-                let immCap = (phase == .preMerge) ? (caps.immunity ?? 3) : (caps.immunity ?? 3) // post-merge may become dynamic
-                Text("Who Will Have Immunity (\(immCap))").font(.headline)
-                LimitedMultiSelect(all: cfg.contestants, selection: Binding(
-                    get: { picks.immunity },
-                    set: { picks.immunity = Set($0.prefix(immCap)) }
-                ), max: immCap, disabled: locked)
-            }
-
-            HStack {
-                Spacer()
-                Button("Save Picks") { app.store.save(picks) }.disabled(locked)
-            }
-        }
-        .onChange(of: episode.id) { _ in
-            var p = app.store.picks(for: userId, episodeId: episode.id)
-            picks = p
-        }
-    }
-}
-
-// MARK: - Table Tab
-
-struct TableView: View {
-    @EnvironmentObject var app: AppState
-
-    var body: some View {
-        let cfg = app.store.config
-        let scoring = app.scoring
-        // Compute scores up to the latest episode with results
-        let lastEp = app.store.results.map { $0.id }.max() ?? 0
-
-        let breakdowns: [UserScoreBreakdown] = app.store.users.map { user in
-            var votedOutPts = 0, remainPts = 0, immunityPts = 0, weeks = 0
-            for ep in cfg.episodes where ep.id <= lastEp {
-                let p = app.store.weeklyPicks[user.id]?[ep.id]
-                if let p { weeks += 1; let s = scoring.score(weekly: p, episode: ep); votedOutPts += s.votedOut; remainPts += s.remain; immunityPts += s.immunity }
-            }
-            let season = app.store.seasonPicks[user.id] ?? SeasonPicks(userId: user.id)
-            let mergePts = scoring.mergeTrackPoints(for: user.id, upTo: lastEp, seasonPicks: season)
-            let f3Pts = scoring.finalThreeTrackPoints(for: user.id, upTo: lastEp, seasonPicks: season)
-            let winnerPts = scoring.winnerPoints(seasonPicks: season, finalResult: nil)
-            return UserScoreBreakdown(userId: user.id, weeksParticipated: weeks, votedOutPoints: votedOutPts, remainPoints: remainPts, immunityPoints: immunityPts, mergeTrackPoints: mergePts, finalThreeTrackPoints: f3Pts, winnerPoints: winnerPts)
-        }
-        .sorted { $0.total > $1.total }
-
-        return NavigationStack {
-            List {
-                TableHeader()
-                ForEach(breakdowns) { b in
-                    HStack {
-                        Text(app.store.users.first(where: { $0.id == b.userId })?.displayName ?? b.userId)
-                        Spacer()
-                        Text("\(b.weeksParticipated)").frame(width: 32)
-                        Text("\(b.votedOutPoints)").frame(width: 40)
-                        Text("\(b.remainPoints)").frame(width: 40)
-                        Text("\(b.immunityPoints)").frame(width: 40)
-                        Text("\(b.total)").fontWeight(.semibold).frame(width: 50, alignment: .trailing)
-                    }
-                }
-            }
-            .navigationTitle("Table")
-        }
-    }
-}
-
-struct TableHeader: View {
-    var body: some View {
-        HStack {
-            Text("Name").fontWeight(.semibold)
-            Spacer()
-            Text("Wk").frame(width: 32)
-            Text("VO").frame(width: 40)
-            Text("RM").frame(width: 40)
-            Text("IM").frame(width: 40)
-            Text("Total").frame(width: 50, alignment: .trailing)
-        }
-        .foregroundStyle(.secondary)
-    }
-}
 
 // MARK: - Reusable UI
 
@@ -295,20 +10,24 @@ struct LimitedMultiSelect: View {
 
     var body: some View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: 110), spacing: 8)], spacing: 8) {
-            ForEach(all) { c in
-                let isOn = selection.contains(c.id)
+            ForEach(all) { contestant in
+                let isSelected = selection.contains(contestant.id)
                 Button {
                     guard !disabled else { return }
-                    if isOn { selection.remove(c.id) }
-                    else if selection.count < max { selection.insert(c.id) }
+                    if isSelected {
+                        selection.remove(contestant.id)
+                    } else if selection.count < max {
+                        selection.insert(contestant.id)
+                    }
                 } label: {
                     HStack(spacing: 6) {
-                        Image(systemName: isOn ? "checkmark.circle.fill" : "circle")
-                        Text(c.name).lineLimit(1)
+                        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        Text(contestant.name).lineLimit(1)
                     }
-                    .padding(.vertical, 8).padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 10)
                     .frame(maxWidth: .infinity)
-                    .background(isOn ? Color.accentColor.opacity(0.15) : Color.secondary.opacity(0.08))
+                    .background(isSelected ? Color.accentColor.opacity(0.15) : Color.secondary.opacity(0.08))
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
                 .buttonStyle(.plain)
@@ -319,10 +38,12 @@ struct LimitedMultiSelect: View {
 
 struct LockPill: View {
     var text: String = "Locked"
+
     var body: some View {
         Text(text)
             .font(.caption2)
-            .padding(.vertical, 4).padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
             .background(Color.red.opacity(0.15))
             .clipShape(Capsule())
     }
@@ -331,7 +52,7 @@ struct LockPill: View {
 // MARK: - Utilities
 
 func picksLocked(for episode: Episode?) -> Bool {
-    guard let ep = episode else { return true }
+    guard let episode else { return true }
     // Demo lock: disable once airDate has passed
-    return Date() >= ep.airDate
+    return Date() >= episode.airDate
 }

--- a/survivus/Features/Picks/FinalThreePickEditor.swift
+++ b/survivus/Features/Picks/FinalThreePickEditor.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct FinalThreePickEditor: View {
+    @EnvironmentObject var app: AppState
+
+    var body: some View {
+        let config = app.store.config
+        let userId = app.currentUserId
+        let afterMerge = config.episodes.contains(where: { $0.isMergeEpisode })
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Final Three Picks (3)").font(.headline)
+                if !afterMerge {
+                    Text("(Available after merge)").foregroundStyle(.secondary)
+                }
+            }
+            LimitedMultiSelect(
+                all: config.contestants,
+                selection: Binding(
+                    get: { app.store.seasonPicks[userId]?.finalThreePicks ?? [] },
+                    set: { newValue in app.store.seasonPicks[userId]?.finalThreePicks = Set(newValue.prefix(3)) }
+                ),
+                max: 3,
+                disabled: !afterMerge
+            )
+        }
+    }
+}

--- a/survivus/Features/Picks/MergePickEditor.swift
+++ b/survivus/Features/Picks/MergePickEditor.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct MergePickEditor: View {
+    @EnvironmentObject var app: AppState
+
+    var body: some View {
+        let config = app.store.config
+        let userId = app.currentUserId
+        let disabled = picksLocked(for: config.episodes.first)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Who Will Make the Merge (3)").font(.headline)
+                if disabled { LockPill() }
+            }
+            LimitedMultiSelect(
+                all: config.contestants,
+                selection: Binding(
+                    get: { app.store.seasonPicks[userId]?.mergePicks ?? [] },
+                    set: { newValue in app.store.seasonPicks[userId]?.mergePicks = Set(newValue.prefix(3)) }
+                ),
+                max: 3,
+                disabled: disabled
+            )
+        }
+    }
+}

--- a/survivus/Features/Picks/PicksView.swift
+++ b/survivus/Features/Picks/PicksView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct PicksView: View {
+    @EnvironmentObject var app: AppState
+    @State private var selectedEpisode: Episode?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Season Picks") {
+                    MergePickEditor()
+                    FinalThreePickEditor()
+                    WinnerPickEditor()
+                }
+
+                Section("Weekly Picks") {
+                    Picker("Episode", selection: Binding(
+                        get: { selectedEpisode?.id ?? app.store.config.episodes.first?.id ?? 1 },
+                        set: { newId in selectedEpisode = app.store.config.episodes.first(where: { $0.id == newId }) }
+                    )) {
+                        ForEach(app.store.config.episodes) { episode in
+                            Text(episode.title).tag(episode.id)
+                        }
+                    }
+                    if let episode = app.store.config.episodes.first(where: { $0.id == (selectedEpisode?.id ?? app.store.config.episodes.first!.id) }) {
+                        WeeklyPickEditor(episode: episode)
+                    }
+                }
+            }
+            .onAppear { if selectedEpisode == nil { selectedEpisode = app.store.config.episodes.first } }
+            .navigationTitle("Picks")
+        }
+    }
+}

--- a/survivus/Features/Picks/WeeklyPickEditor.swift
+++ b/survivus/Features/Picks/WeeklyPickEditor.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct WeeklyPickEditor: View {
+    @EnvironmentObject var app: AppState
+    let episode: Episode
+    @State private var picks: WeeklyPicks
+
+    init(episode: Episode) {
+        self.episode = episode
+        _picks = State(initialValue: WeeklyPicks(userId: "", episodeId: episode.id))
+    }
+
+    var body: some View {
+        let config = app.store.config
+        let userId = app.currentUserId
+        let phase = app.scoring.phase(for: episode)
+        let caps = (phase == .preMerge) ? config.weeklyPickCapsPreMerge : config.weeklyPickCapsPostMerge
+        let locked = picksLocked(for: episode)
+        let remainCap = caps.remain ?? 3
+        let votedOutCap = caps.votedOut ?? 3
+        let immunityCap = caps.immunity ?? 3
+
+        VStack(alignment: .leading, spacing: 16) {
+            if locked {
+                LockPill(text: "Locked for \(episode.title)")
+            }
+
+            Group {
+                Text("Who Will Remain (\(remainCap))").font(.headline)
+                LimitedMultiSelect(
+                    all: config.contestants,
+                    selection: Binding(
+                        get: { picks.remain },
+                        set: { picks.remain = Set($0.prefix(remainCap)) }
+                    ),
+                    max: remainCap,
+                    disabled: locked
+                )
+            }
+
+            Group {
+                Text("Who Will be Voted Out (\(votedOutCap))").font(.headline)
+                LimitedMultiSelect(
+                    all: config.contestants,
+                    selection: Binding(
+                        get: { picks.votedOut },
+                        set: { picks.votedOut = Set($0.prefix(votedOutCap)) }
+                    ),
+                    max: votedOutCap,
+                    disabled: locked
+                )
+            }
+
+            Group {
+                Text("Who Will Have Immunity (\(immunityCap))").font(.headline)
+                LimitedMultiSelect(
+                    all: config.contestants,
+                    selection: Binding(
+                        get: { picks.immunity },
+                        set: { picks.immunity = Set($0.prefix(immunityCap)) }
+                    ),
+                    max: immunityCap,
+                    disabled: locked
+                )
+            }
+
+            HStack {
+                Spacer()
+                Button("Save Picks") { app.store.save(picks) }
+                    .disabled(locked)
+            }
+        }
+        .onAppear { loadPicks(for: userId) }
+        .onChange(of: episode.id) { _ in loadPicks(for: userId) }
+        .onChange(of: app.currentUserId) { newValue in loadPicks(for: newValue) }
+    }
+
+    private func loadPicks(for userId: String) {
+        picks = app.store.picks(for: userId, episodeId: episode.id)
+    }
+}

--- a/survivus/Features/Picks/WinnerPickEditor.swift
+++ b/survivus/Features/Picks/WinnerPickEditor.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct WinnerPickEditor: View {
+    @EnvironmentObject var app: AppState
+
+    var body: some View {
+        let config = app.store.config
+        let userId = app.currentUserId
+        let enable = config.episodes.count >= 2
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Sole Survivor (1)").font(.headline)
+                if !enable {
+                    Text("(Available after Final Three)").foregroundStyle(.secondary)
+                }
+            }
+            Picker("Winner", selection: Binding(
+                get: { app.store.seasonPicks[userId]?.winnerPick ?? "" },
+                set: { app.store.seasonPicks[userId]?.winnerPick = $0.isEmpty ? nil : $0 }
+            )) {
+                Text("—").tag("")
+                ForEach(app.store.config.contestants) { contestant in
+                    Text(contestant.name).tag(contestant.id)
+                }
+            }
+            .disabled(!enable)
+        }
+    }
+}

--- a/survivus/Features/Results/ResultsView.swift
+++ b/survivus/Features/Results/ResultsView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct ResultsView: View {
+    @EnvironmentObject var app: AppState
+
+    var body: some View {
+        NavigationStack {
+            List(app.store.config.episodes) { episode in
+                let result = app.store.resultsByEpisode[episode.id]
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(episode.title).font(.headline)
+                        if episode.isMergeEpisode {
+                            Text("MERGE")
+                                .font(.caption2)
+                                .padding(4)
+                                .background(Color.yellow.opacity(0.3))
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                        }
+                        Spacer()
+                        Text(episode.airDate, style: .date).foregroundStyle(.secondary)
+                    }
+                    if let result {
+                        if !result.immunityWinners.isEmpty {
+                            Text("Immunity: " + result.immunityWinners.compactMap { id in
+                                app.store.config.contestants.first { $0.id == id }?.name
+                            }.joined(separator: ", "))
+                        }
+                        if !result.votedOut.isEmpty {
+                            Text("Voted out: " + result.votedOut.compactMap { id in
+                                app.store.config.contestants.first { $0.id == id }?.name
+                            }.joined(separator: ", "))
+                        }
+                    } else {
+                        Text("No result yet").foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Results")
+        }
+    }
+}

--- a/survivus/Features/Table/TableView.swift
+++ b/survivus/Features/Table/TableView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct TableView: View {
+    @EnvironmentObject var app: AppState
+
+    var body: some View {
+        let config = app.store.config
+        let scoring = app.scoring
+        let lastEpisodeWithResult = app.store.results.map { $0.id }.max() ?? 0
+
+        let breakdowns: [UserScoreBreakdown] = app.store.users.map { user in
+            var votedOutPoints = 0
+            var remainPoints = 0
+            var immunityPoints = 0
+            var weeksParticipated = 0
+
+            for episode in config.episodes where episode.id <= lastEpisodeWithResult {
+                if let picks = app.store.weeklyPicks[user.id]?[episode.id] {
+                    weeksParticipated += 1
+                    let score = scoring.score(weekly: picks, episode: episode)
+                    votedOutPoints += score.votedOut
+                    remainPoints += score.remain
+                    immunityPoints += score.immunity
+                }
+            }
+
+            let season = app.store.seasonPicks[user.id] ?? SeasonPicks(userId: user.id)
+            let mergePoints = scoring.mergeTrackPoints(for: user.id, upTo: lastEpisodeWithResult, seasonPicks: season)
+            let finalThreePoints = scoring.finalThreeTrackPoints(for: user.id, upTo: lastEpisodeWithResult, seasonPicks: season)
+            let winnerPoints = scoring.winnerPoints(seasonPicks: season, finalResult: nil)
+
+            return UserScoreBreakdown(
+                userId: user.id,
+                weeksParticipated: weeksParticipated,
+                votedOutPoints: votedOutPoints,
+                remainPoints: remainPoints,
+                immunityPoints: immunityPoints,
+                mergeTrackPoints: mergePoints,
+                finalThreeTrackPoints: finalThreePoints,
+                winnerPoints: winnerPoints
+            )
+        }
+        .sorted { $0.total > $1.total }
+
+        return NavigationStack {
+            List {
+                TableHeader()
+                ForEach(breakdowns) { breakdown in
+                    HStack {
+                        Text(app.store.users.first(where: { $0.id == breakdown.userId })?.displayName ?? breakdown.userId)
+                        Spacer()
+                        Text("\(breakdown.weeksParticipated)").frame(width: 32)
+                        Text("\(breakdown.votedOutPoints)").frame(width: 40)
+                        Text("\(breakdown.remainPoints)").frame(width: 40)
+                        Text("\(breakdown.immunityPoints)").frame(width: 40)
+                        Text("\(breakdown.total)").fontWeight(.semibold).frame(width: 50, alignment: .trailing)
+                    }
+                }
+            }
+            .navigationTitle("Table")
+        }
+    }
+}
+
+struct TableHeader: View {
+    var body: some View {
+        HStack {
+            Text("Name").fontWeight(.semibold)
+            Spacer()
+            Text("Wk").frame(width: 32)
+            Text("VO").frame(width: 40)
+            Text("RM").frame(width: 40)
+            Text("IM").frame(width: 40)
+            Text("Total").frame(width: 50, alignment: .trailing)
+        }
+        .foregroundStyle(.secondary)
+    }
+}

--- a/survivus/survivusApp.swift
+++ b/survivus/survivusApp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @main
 struct survivusApp: App {
-    @StateObject private var app = AppState()   // add this line
+    @StateObject private var app = AppState()
 
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
## Summary
- move the Results, Picks, and Table tabs into dedicated feature directories
- split each picks editor into its own file and fix the weekly editor’s state management
- leave shared UI helpers in ContentView and tidy the app entry point

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de1881aa848329a6417ee2e483fe9a