### PR TITLE
Extract shared components into Shared/Components

### DIFF
--- a/survivus/ContentView.swift
+++ b/survivus/ContentView.swift
@@ -1,53 +1,6 @@
 import SwiftUI
-
-// MARK: - Reusable UI
-
-struct LimitedMultiSelect: View {
-    let all: [Contestant]
-    @Binding var selection: Set<String>
-    let max: Int
-    var disabled: Bool = false
-
-    var body: some View {
-        LazyVGrid(columns: [GridItem(.adaptive(minimum: 110), spacing: 8)], spacing: 8) {
-            ForEach(all) { contestant in
-                let isSelected = selection.contains(contestant.id)
-                Button {
-                    guard !disabled else { return }
-                    if isSelected {
-                        selection.remove(contestant.id)
-                    } else if selection.count < max {
-                        selection.insert(contestant.id)
-                    }
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                        Text(contestant.name).lineLimit(1)
-                    }
-                    .padding(.vertical, 8)
-                    .padding(.horizontal, 10)
-                    .frame(maxWidth: .infinity)
-                    .background(isSelected ? Color.accentColor.opacity(0.15) : Color.secondary.opacity(0.08))
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-}
-
-struct LockPill: View {
-    var text: String = "Locked"
-
-    var body: some View {
-        Text(text)
-            .font(.caption2)
-            .padding(.vertical, 4)
-            .padding(.horizontal, 8)
-            .background(Color.red.opacity(0.15))
-            .clipShape(Capsule())
-    }
-}
+import struct survivus.LimitedMultiSelect
+import struct survivus.LockPill
 
 // MARK: - Utilities
 

--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// A grid-based multi-select control that limits how many contestants can be chosen.
+///
+/// Provide the complete list of contestants with a binding to the set of selected
+/// contestant identifiers. The view enforces the `max` limit and optionally allows
+/// disabling user interaction.
+struct LimitedMultiSelect: View {
+    let all: [Contestant]
+    @Binding var selection: Set<String>
+    let max: Int
+    var disabled: Bool = false
+
+    var body: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 110), spacing: 8)], spacing: 8) {
+            ForEach(all) { contestant in
+                let isSelected = selection.contains(contestant.id)
+                Button {
+                    guard !disabled else { return }
+                    if isSelected {
+                        selection.remove(contestant.id)
+                    } else if selection.count < max {
+                        selection.insert(contestant.id)
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        Text(contestant.name).lineLimit(1)
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 10)
+                    .frame(maxWidth: .infinity)
+                    .background(isSelected ? Color.accentColor.opacity(0.15) : Color.secondary.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+#Preview("LimitedMultiSelect") {
+    LimitedMultiSelectPreview()
+}
+
+private struct LimitedMultiSelectPreview: View {
+    @State private var selection: Set<String> = ["parvati"]
+    private let contestants: [Contestant] = [
+        Contestant(id: "parvati", name: "Parvati"),
+        Contestant(id: "sandra", name: "Sandra"),
+        Contestant(id: "tony", name: "Tony"),
+        Contestant(id: "denise", name: "Denise"),
+        Contestant(id: "adam", name: "Adam"),
+    ]
+
+    var body: some View {
+        LimitedMultiSelect(
+            all: contestants,
+            selection: $selection,
+            max: 3
+        )
+        .padding()
+    }
+}

--- a/survivus/Shared/Components/LockPill.swift
+++ b/survivus/Shared/Components/LockPill.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// A compact pill-shaped label that communicates a locked state in the UI.
+///
+/// The pill defaults to the text "Locked", but you can supply a custom message
+/// to indicate why the surrounding content is unavailable.
+struct LockPill: View {
+    var text: String = "Locked"
+
+    var body: some View {
+        Text(text)
+            .font(.caption2)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .background(Color.red.opacity(0.15))
+            .clipShape(Capsule())
+    }
+}
+
+#Preview("LockPill") {
+    VStack(spacing: 12) {
+        LockPill()
+        LockPill(text: "Locked for Episode 3")
+    }
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}


### PR DESCRIPTION
## Summary
- add a Shared/Components folder for reusable SwiftUI components
- move LimitedMultiSelect and LockPill into dedicated files with documentation previews
- update ContentView to import the shared components instead of defining them inline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de1a0435088329bc5b78d3ba31bb78