### PR TITLE
Update mock Survivor roster with provided contestants

### DIFF
--- a/survivus/Mocks/MockData.swift
+++ b/survivus/Mocks/MockData.swift
@@ -1,21 +1,21 @@
 import Foundation
 
+private let mockContestantData: [(id: String, name: String)] = [
+    ("courtney_yates", "Courtney Yates"),
+    ("todd_herzog", "Todd Herzog"),
+    ("boston_rob", "Boston Rob"),
+    ("russell_hantz", "Russell Hantz"),
+    ("john_cochran", "John Cochran"),
+    ("tony_vlachos", "Tony Vlachos"),
+    ("q", "Q"),
+    ("eva_erickson", "Eva Erickson"),
+    ("mitch_guerra", "Mitch Guerra"),
+    ("erik_reichenbach", "Erik Reichenbach")
+]
+
 extension SeasonConfig {
     static func mock() -> SeasonConfig {
-        let contestants: [Contestant] = [
-            .init(id: "c01", name: "Alex"),
-            .init(id: "c02", name: "Bailey"),
-            .init(id: "c03", name: "Casey"),
-            .init(id: "c04", name: "Drew"),
-            .init(id: "c05", name: "Eden"),
-            .init(id: "c06", name: "Finn"),
-            .init(id: "c07", name: "Gray"),
-            .init(id: "c08", name: "Harper"),
-            .init(id: "c09", name: "Indy"),
-            .init(id: "c10", name: "Jules"),
-            .init(id: "c11", name: "Kai"),
-            .init(id: "c12", name: "Lane")
-        ]
+        let contestants: [Contestant] = mockContestantData.map { .init(id: $0.id, name: $0.name) }
         let base = Date()
         let episodes = (1...12).map { index -> Episode in
             Episode(
@@ -31,8 +31,9 @@ extension SeasonConfig {
 
 extension EpisodeResult {
     static func mock(episodeId: Int) -> EpisodeResult {
-        let immunity = ["c0\(((episodeId - 1) % 3) + 1)"]
-        let votedOut = episodeId <= 10 ? ["c0\(((episodeId) % 12) + 1)"] : []
+        let contestantIds = mockContestantData.map { $0.id }
+        let immunity = [contestantIds[(episodeId - 1) % contestantIds.count]]
+        let votedOut = episodeId <= contestantIds.count ? [contestantIds[episodeId % contestantIds.count]] : []
         return EpisodeResult(id: episodeId, immunityWinners: immunity, votedOut: votedOut)
     }
 }

--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -44,13 +44,13 @@ struct LimitedMultiSelect: View {
 }
 
 private struct LimitedMultiSelectPreview: View {
-    @State private var selection: Set<String> = ["parvati"]
+    @State private var selection: Set<String> = ["courtney_yates"]
     private let contestants: [Contestant] = [
-        Contestant(id: "parvati", name: "Parvati"),
-        Contestant(id: "sandra", name: "Sandra"),
-        Contestant(id: "tony", name: "Tony"),
-        Contestant(id: "denise", name: "Denise"),
-        Contestant(id: "adam", name: "Adam"),
+        Contestant(id: "courtney_yates", name: "Courtney Yates"),
+        Contestant(id: "todd_herzog", name: "Todd Herzog"),
+        Contestant(id: "boston_rob", name: "Boston Rob"),
+        Contestant(id: "russell_hantz", name: "Russell Hantz"),
+        Contestant(id: "john_cochran", name: "John Cochran"),
     ]
 
     var body: some View {


### PR DESCRIPTION
## Summary
- replace the mock contestant data with the newly requested Survivor roster
- update the limited multi-select preview to display the refreshed contestant names

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de27b5184c8329b421c2403879a3e1