### PR TITLE
Add contestant avatars beside names in picks and results views

### DIFF
--- a/survivus/Shared/Components/ContestantIdentityViews.swift
+++ b/survivus/Shared/Components/ContestantIdentityViews.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Displays a contestant's circular avatar using the image that matches the contestant identifier.
+struct ContestantAvatar: View {
+    let imageName: String
+    var size: CGFloat = 28
+
+    var body: some View {
+        ZStack {
+            Circle().fill(Color.secondary.opacity(0.2))
+            if let image = loadImage(named: imageName) {
+                image
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Image(systemName: "person.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .padding(size * 0.25)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .overlay(Circle().stroke(Color.white.opacity(0.7), lineWidth: 1))
+        .shadow(color: Color.black.opacity(0.08), radius: 1, y: 0.5)
+        .accessibilityHidden(true)
+    }
+
+    private func loadImage(named: String) -> Image? {
+        #if canImport(UIKit)
+        if let uiImage = UIImage(named: named) {
+            return Image(uiImage: uiImage)
+        }
+        #endif
+        return nil
+    }
+}
+
+/// Convenience view that displays a contestant avatar beside their name.
+struct ContestantNameLabel: View {
+    let contestant: Contestant
+    var avatarSize: CGFloat = 24
+    var font: Font = .body
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ContestantAvatar(imageName: contestant.id, size: avatarSize)
+            Text(contestant.name)
+                .font(font)
+                .foregroundStyle(.primary)
+        }
+    }
+}
+
+#Preview("ContestantNameLabel") {
+    VStack(alignment: .leading, spacing: 12) {
+        ContestantNameLabel(contestant: Contestant(id: "courtney_yates", name: "Courtney Yates"))
+        ContestantNameLabel(contestant: Contestant(id: "john_cochran", name: "John Cochran"), avatarSize: 30, font: .title3)
+    }
+    .padding()
+}

--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -23,9 +23,14 @@ struct LimitedMultiSelect: View {
                         selection.insert(contestant.id)
                     }
                 } label: {
-                    HStack(spacing: 6) {
+                    HStack(spacing: 10) {
+                        ContestantAvatar(imageName: contestant.id, size: 32)
+                        Text(contestant.name)
+                            .lineLimit(1)
+                            .font(.subheadline)
+                        Spacer(minLength: 4)
                         Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                        Text(contestant.name).lineLimit(1)
+                            .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
                     }
                     .padding(.vertical, 8)
                     .padding(.horizontal, 10)


### PR DESCRIPTION
## Summary
- add reusable contestant avatar and name views for contestant imagery
- show contestant portraits next to names in the Results view
- update the multi-select pick controls to include contestant avatars

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68de2f0135c0832991cbb5e09b92491a