### PR TITLE
Unify picks accordion behavior across season and weekly picks

### DIFF
--- a/survivus/Features/Picks/FinalThreePickEditor.swift
+++ b/survivus/Features/Picks/FinalThreePickEditor.swift
@@ -2,18 +2,13 @@ import SwiftUI
 
 struct FinalThreePickEditor: View {
     @EnvironmentObject var app: AppState
+    @Binding var isExpanded: Bool
 
     var body: some View {
         let config = app.store.config
         let userId = app.currentUserId
         let afterMerge = config.episodes.contains(where: { $0.isMergeEpisode })
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Final Three Picks (3)").font(.headline)
-                if !afterMerge {
-                    Text("(Available after merge)").foregroundStyle(.secondary)
-                }
-            }
+        DisclosureGroup(isExpanded: $isExpanded) {
             LimitedMultiSelect(
                 all: config.contestants,
                 selection: Binding(
@@ -23,6 +18,16 @@ struct FinalThreePickEditor: View {
                 max: 3,
                 disabled: !afterMerge
             )
+            .padding(.top, 4)
+        } label: {
+            HStack {
+                Text("Final Three Picks (3)")
+                    .font(.headline)
+                if !afterMerge {
+                    Text("(Available after merge)")
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
     }
 }

--- a/survivus/Features/Picks/MergePickEditor.swift
+++ b/survivus/Features/Picks/MergePickEditor.swift
@@ -2,16 +2,13 @@ import SwiftUI
 
 struct MergePickEditor: View {
     @EnvironmentObject var app: AppState
+    @Binding var isExpanded: Bool
 
     var body: some View {
         let config = app.store.config
         let userId = app.currentUserId
         let disabled = picksLocked(for: config.episodes.first)
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Who Will Make the Merge (3)").font(.headline)
-                if disabled { LockPill() }
-            }
+        DisclosureGroup(isExpanded: $isExpanded) {
             LimitedMultiSelect(
                 all: config.contestants,
                 selection: Binding(
@@ -21,6 +18,13 @@ struct MergePickEditor: View {
                 max: 3,
                 disabled: disabled
             )
+            .padding(.top, 4)
+        } label: {
+            HStack {
+                Text("Who Will Make the Merge (3)")
+                    .font(.headline)
+                if disabled { LockPill() }
+            }
         }
     }
 }

--- a/survivus/Features/Picks/PicksView.swift
+++ b/survivus/Features/Picks/PicksView.swift
@@ -3,14 +3,16 @@ import SwiftUI
 struct PicksView: View {
     @EnvironmentObject var app: AppState
     @State private var selectedEpisode: Episode?
+    @State private var expandedSeasonPick: SeasonPickPanel? = .merge
+    @State private var expandedWeeklyPick: WeeklyPickPanel?
 
     var body: some View {
         NavigationStack {
             Form {
                 Section("Season Picks") {
-                    MergePickEditor()
-                    FinalThreePickEditor()
-                    WinnerPickEditor()
+                    MergePickEditor(isExpanded: seasonBinding(for: .merge))
+                    FinalThreePickEditor(isExpanded: seasonBinding(for: .finalThree))
+                    WinnerPickEditor(isExpanded: seasonBinding(for: .winner))
                 }
 
                 Section("Weekly Picks") {
@@ -23,7 +25,11 @@ struct PicksView: View {
                         }
                     }
                     if let episode = app.store.config.episodes.first(where: { $0.id == (selectedEpisode?.id ?? app.store.config.episodes.first!.id) }) {
-                        WeeklyPickEditor(episode: episode)
+                        WeeklyPickEditor(
+                            episode: episode,
+                            expandedPanel: $expandedWeeklyPick,
+                            collapseSeasonPanels: { expandedSeasonPick = nil }
+                        )
                     }
                 }
             }
@@ -31,4 +37,25 @@ struct PicksView: View {
             .navigationTitle("Picks")
         }
     }
+
+    private func seasonBinding(for panel: SeasonPickPanel) -> Binding<Bool> {
+        Binding(
+            get: { expandedSeasonPick == panel },
+            set: { newValue in
+                if newValue {
+                    expandedWeeklyPick = nil
+                    expandedSeasonPick = panel
+                } else if expandedSeasonPick == panel {
+                    expandedSeasonPick = nil
+                }
+            }
+        )
+    }
+
+}
+
+private enum SeasonPickPanel: Hashable {
+    case merge
+    case finalThree
+    case winner
 }

--- a/survivus/Features/Picks/WinnerPickEditor.swift
+++ b/survivus/Features/Picks/WinnerPickEditor.swift
@@ -2,18 +2,13 @@ import SwiftUI
 
 struct WinnerPickEditor: View {
     @EnvironmentObject var app: AppState
+    @Binding var isExpanded: Bool
 
     var body: some View {
         let config = app.store.config
         let userId = app.currentUserId
         let enable = config.episodes.count >= 2
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Sole Survivor (1)").font(.headline)
-                if !enable {
-                    Text("(Available after Final Three)").foregroundStyle(.secondary)
-                }
-            }
+        DisclosureGroup(isExpanded: $isExpanded) {
             Picker("Winner", selection: Binding(
                 get: { app.store.seasonPicks[userId]?.winnerPick ?? "" },
                 set: { app.store.seasonPicks[userId]?.winnerPick = $0.isEmpty ? nil : $0 }
@@ -24,6 +19,16 @@ struct WinnerPickEditor: View {
                 }
             }
             .disabled(!enable)
+            .padding(.top, 4)
+        } label: {
+            HStack {
+                Text("Sole Survivor (1)")
+                    .font(.headline)
+                if !enable {
+                    Text("(Available after Final Three)")
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
     }
 }

--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -11,8 +11,10 @@ struct LimitedMultiSelect: View {
     let max: Int
     var disabled: Bool = false
 
+    private let columns: [GridItem] = Array(repeating: GridItem(.flexible(), spacing: 16), count: 2)
+
     var body: some View {
-        LazyVGrid(columns: [GridItem(.adaptive(minimum: 110), spacing: 8)], spacing: 8) {
+        LazyVGrid(columns: columns, spacing: 16) {
             ForEach(all) { contestant in
                 let isSelected = selection.contains(contestant.id)
                 Button {
@@ -23,22 +25,35 @@ struct LimitedMultiSelect: View {
                         selection.insert(contestant.id)
                     }
                 } label: {
-                    HStack(spacing: 10) {
-                        ContestantAvatar(imageName: contestant.id, size: 32)
+                    VStack(spacing: 12) {
+                        ContestantAvatar(imageName: contestant.id, size: 72)
                         Text(contestant.name)
-                            .lineLimit(1)
-                            .font(.subheadline)
-                        Spacer(minLength: 4)
-                        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                            .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(2)
+                            .minimumScaleFactor(0.85)
                     }
-                    .padding(.vertical, 8)
-                    .padding(.horizontal, 10)
-                    .frame(maxWidth: .infinity)
-                    .background(isSelected ? Color.accentColor.opacity(0.15) : Color.secondary.opacity(0.08))
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .frame(maxWidth: .infinity, minHeight: 160)
+                    .padding(.vertical, 16)
+                    .padding(.horizontal, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .fill(isSelected ? Color.accentColor.opacity(0.2) : Color.secondary.opacity(0.08))
+                    )
+                    .overlay(alignment: .topTrailing) {
+                        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                            .font(.title3)
+                            .foregroundStyle(isSelected ? Color.accentColor : Color.secondary.opacity(0.6))
+                            .padding(10)
+                    }
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .stroke(isSelected ? Color.accentColor : Color.secondary.opacity(0.15), lineWidth: isSelected ? 2 : 1)
+                    )
                 }
                 .buttonStyle(.plain)
+                .contentShape(Rectangle())
             }
         }
     }


### PR DESCRIPTION
## Summary
- share state between season and weekly pick sections so expanding one collapses the other
- wrap weekly pick categories in disclosure groups using the shared expansion state

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de317afcd483298ca9913c12dcf5fa