### PR TITLE
Reorder results list and emphasize weekly pick headings

### DIFF
--- a/survivus/Features/Picks/WeeklyPickEditor.swift
+++ b/survivus/Features/Picks/WeeklyPickEditor.swift
@@ -27,7 +27,7 @@ struct WeeklyPickEditor: View {
                 LockPill(text: "Locked for \(episode.title)")
             }
 
-            DisclosureGroup("Who Will Remain (\(remainCap))", isExpanded: binding(for: .remain)) {
+            DisclosureGroup(isExpanded: binding(for: .remain)) {
                 LimitedMultiSelect(
                     all: config.contestants,
                     selection: Binding(
@@ -38,9 +38,12 @@ struct WeeklyPickEditor: View {
                     disabled: locked
                 )
                 .padding(.top, 4)
+            } label: {
+                Text("Who Will Remain (\(remainCap))")
+                    .font(.headline)
             }
 
-            DisclosureGroup("Who Will be Voted Out (\(votedOutCap))", isExpanded: binding(for: .votedOut)) {
+            DisclosureGroup(isExpanded: binding(for: .votedOut)) {
                 LimitedMultiSelect(
                     all: config.contestants,
                     selection: Binding(
@@ -51,9 +54,12 @@ struct WeeklyPickEditor: View {
                     disabled: locked
                 )
                 .padding(.top, 4)
+            } label: {
+                Text("Who Will be Voted Out (\(votedOutCap))")
+                    .font(.headline)
             }
 
-            DisclosureGroup("Who Will Have Immunity (\(immunityCap))", isExpanded: binding(for: .immunity)) {
+            DisclosureGroup(isExpanded: binding(for: .immunity)) {
                 LimitedMultiSelect(
                     all: config.contestants,
                     selection: Binding(
@@ -64,6 +70,9 @@ struct WeeklyPickEditor: View {
                     disabled: locked
                 )
                 .padding(.top, 4)
+            } label: {
+                Text("Who Will Have Immunity (\(immunityCap))")
+                    .font(.headline)
             }
 
             HStack {

--- a/survivus/Features/Results/ResultsView.swift
+++ b/survivus/Features/Results/ResultsView.swift
@@ -9,7 +9,7 @@ struct ResultsView: View {
 
     var body: some View {
         NavigationStack {
-            List(app.store.config.episodes) { episode in
+            List(app.store.config.episodes.sorted(by: { $0.airDate > $1.airDate })) { episode in
                 let result = app.store.resultsByEpisode[episode.id]
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {


### PR DESCRIPTION
## Summary
- show the most recent episodes first in the results list
- style weekly pick disclosure headings with bold text for better emphasis

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de3990c2488329a92b4bb4e2d44537