### PR TITLE
Adjust table tab name text size

### DIFF
--- a/survivus/Features/Table/TableView.swift
+++ b/survivus/Features/Table/TableView.swift
@@ -56,8 +56,12 @@ struct TableView: View {
                                 .clipShape(Circle())
                                 .accessibilityHidden(true)
                             Text(user.displayName)
+                                .font(.subheadline)
+                                .lineLimit(1)
                         } else {
                             Text(breakdown.userId)
+                                .font(.subheadline)
+                                .lineLimit(1)
                         }
                         Spacer()
                         Text("\(breakdown.weeksParticipated)").frame(width: 32)


### PR DESCRIPTION
## Summary
- reduce the contestant name text in the Table tab to a smaller subheadline font and enforce a single line to avoid wrapping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de455cb73883299a1fd26922266097