### PR TITLE
Add All Picks tab with week selector

### DIFF
--- a/survivus/Features/Picks/AllPicksView.swift
+++ b/survivus/Features/Picks/AllPicksView.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+struct AllPicksView: View {
+    @EnvironmentObject var app: AppState
+    @State private var selectedWeekId: Int = 13
+
+    private var weekOptions: [WeekOption] {
+        var options = app.store.config.episodes.map { WeekOption(id: $0.id, title: $0.title) }
+        if let index = options.firstIndex(where: { $0.id == 13 }) {
+            options[index] = WeekOption(id: 13, title: "Week 13 (Current)")
+        } else {
+            options.append(WeekOption(id: 13, title: "Week 13 (Current)"))
+        }
+        return options.sorted { $0.id < $1.id }
+    }
+
+    private var contestantsById: [String: Contestant] {
+        Dictionary(uniqueKeysWithValues: app.store.config.contestants.map { ($0.id, $0) })
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    weekPicker
+                        .padding(.bottom, 8)
+
+                    ForEach(app.store.users) { user in
+                        UserPicksCard(
+                            user: user,
+                            seasonPicks: app.store.seasonPicks[user.id],
+                            weeklyPicks: app.store.weeklyPicks[user.id]?[selectedWeekId],
+                            contestantsById: contestantsById
+                        )
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("All Picks")
+        }
+    }
+
+    private var weekPicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Week")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            Picker("Week", selection: $selectedWeekId) {
+                ForEach(weekOptions) { option in
+                    Text(option.title)
+                        .tag(option.id)
+                }
+            }
+            .pickerStyle(.menu)
+        }
+    }
+}
+
+private struct UserPicksCard: View {
+    let user: UserProfile
+    let seasonPicks: SeasonPicks?
+    let weeklyPicks: WeeklyPicks?
+    let contestantsById: [String: Contestant]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 12) {
+                Image(user.avatarAssetName)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 44, height: 44)
+                    .clipShape(Circle())
+                    .accessibilityHidden(true)
+
+                Text(user.displayName)
+                    .font(.title3)
+                    .fontWeight(.semibold)
+            }
+
+            PickSection(
+                title: "Mergers",
+                contestants: contestants(for: seasonPicks?.mergePicks ?? [])
+            )
+
+            PickSection(
+                title: "Immunity",
+                contestants: contestants(for: weeklyPicks?.immunity ?? [])
+            )
+
+            PickSection(
+                title: "Voted Out",
+                contestants: contestants(for: weeklyPicks?.votedOut ?? [])
+            )
+
+            PickSection(
+                title: "Remain",
+                contestants: contestants(for: weeklyPicks?.remain ?? [])
+            )
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+
+    private func contestants(for ids: Set<String>) -> [Contestant] {
+        ids.compactMap { contestantsById[$0] }
+            .sorted { $0.name < $1.name }
+    }
+}
+
+private struct PickSection: View {
+    let title: String
+    let contestants: [Contestant]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+
+            if contestants.isEmpty {
+                Text("No picks yet")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 80), spacing: 12, alignment: .top)], spacing: 12) {
+                    ForEach(contestants) { contestant in
+                        VStack(spacing: 8) {
+                            Image(contestant.id)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 60, height: 60)
+                                .clipShape(Circle())
+                                .accessibilityLabel(contestant.name)
+
+                            Text(contestant.name)
+                                .font(.caption)
+                                .multilineTextAlignment(.center)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct WeekOption: Identifiable {
+    let id: Int
+    let title: String
+}
+
+#Preview {
+    AllPicksView()
+        .environmentObject(AppState())
+}

--- a/survivus/Features/Picks/PicksView.swift
+++ b/survivus/Features/Picks/PicksView.swift
@@ -29,7 +29,7 @@ struct PicksView: View {
                 }
             }
             .onAppear { if selectedEpisode == nil { selectedEpisode = app.store.config.episodes.first } }
-            .navigationTitle("Picks")
+            .navigationTitle("Your Picks")
         }
     }
 

--- a/survivus/survivusApp.swift
+++ b/survivus/survivusApp.swift
@@ -12,7 +12,10 @@ struct SurvivusApp: App {
                     .tabItem { Label("Results", systemImage: "list.bullet.rectangle") }
                 PicksView()
                     .environmentObject(app)
-                    .tabItem { Label("Picks", systemImage: "checkmark.square") }
+                    .tabItem { Label("Your Picks", systemImage: "checkmark.square") }
+                AllPicksView()
+                    .environmentObject(app)
+                    .tabItem { Label("All Picks", systemImage: "person.3") }
                 TableView()
                     .environmentObject(app)
                     .tabItem { Label("Table", systemImage: "tablecells") }


### PR DESCRIPTION
## Summary
- rename the picks tab to "Your Picks" and update its navigation title
- add a new All Picks tab that shows each player's season and weekly selections
- include a week picker defaulting to Week 13 (Current) for filtering weekly picks

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de4b8c4798832999d699807b6ca61d