### PR TITLE
Fix AppState initialization order

### DIFF
--- a/survivus/Services/AppState.swift
+++ b/survivus/Services/AppState.swift
@@ -19,8 +19,8 @@ final class AppState: ObservableObject {
             UserProfile(id: "u4", displayName: "Liz", avatarAssetName: "liz")
         ]
         self.store = MemoryStore(config: config, results: results, users: users)
-        self.store.loadMockPicks()
         self.currentUserId = users.first!.id
+        self.store.loadMockPicks()
     }
 
     var scoring: ScoringEngine {


### PR DESCRIPTION
## Summary
- move the `loadMockPicks` call until after all AppState stored properties are initialized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de503dffc08329bf4dbfa5bfd18ce5