### PR TITLE
Update picks tab configuration

### DIFF
--- a/survivus/Features/Picks/AllPicksView.swift
+++ b/survivus/Features/Picks/AllPicksView.swift
@@ -36,7 +36,7 @@ struct AllPicksView: View {
                 }
                 .padding()
             }
-            .navigationTitle("All Picks")
+            .navigationTitle("Picks")
         }
     }
 

--- a/survivus/survivusApp.swift
+++ b/survivus/survivusApp.swift
@@ -10,12 +10,9 @@ struct SurvivusApp: App {
                 ResultsView()
                     .environmentObject(app)
                     .tabItem { Label("Results", systemImage: "list.bullet.rectangle") }
-                PicksView()
-                    .environmentObject(app)
-                    .tabItem { Label("Your Picks", systemImage: "checkmark.square") }
                 AllPicksView()
                     .environmentObject(app)
-                    .tabItem { Label("All Picks", systemImage: "person.3") }
+                    .tabItem { Label("Picks", systemImage: "checkmark.circle") }
                 TableView()
                     .environmentObject(app)
                     .tabItem { Label("Table", systemImage: "tablecells") }


### PR DESCRIPTION
## Summary
- remove the Your Picks tab from the main TabView
- rename the All Picks tab to Picks and update its icon to checkmark.circle
- align the Picks screen navigation title with the new name

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de63866b008329b84d1d1218297105