### PR TITLE
Limit picks and results to first two weeks

### DIFF
--- a/survivus/Features/Picks/AllPicksView.swift
+++ b/survivus/Features/Picks/AllPicksView.swift
@@ -2,16 +2,13 @@ import SwiftUI
 
 struct AllPicksView: View {
     @EnvironmentObject var app: AppState
-    @State private var selectedWeekId: Int = 13
+    @State private var selectedWeekId: Int = 1
 
     private var weekOptions: [WeekOption] {
-        var options = app.store.config.episodes.map { WeekOption(id: $0.id, title: $0.title) }
-        if let index = options.firstIndex(where: { $0.id == 13 }) {
-            options[index] = WeekOption(id: 13, title: "Week 13 (Current)")
-        } else {
-            options.append(WeekOption(id: 13, title: "Week 13 (Current)"))
-        }
-        return options.sorted { $0.id < $1.id }
+        app.store.config.episodes
+            .filter { $0.id <= 2 }
+            .map { WeekOption(id: $0.id, title: $0.title) }
+            .sorted { $0.id < $1.id }
     }
 
     private var contestantsById: [String: Contestant] {
@@ -35,6 +32,11 @@ struct AllPicksView: View {
                     }
                 }
                 .padding()
+            }
+            .onAppear {
+                if let firstWeek = weekOptions.first {
+                    selectedWeekId = firstWeek.id
+                }
             }
             .navigationTitle("Picks")
         }

--- a/survivus/Features/Results/ResultsView.swift
+++ b/survivus/Features/Results/ResultsView.swift
@@ -7,9 +7,15 @@ struct ResultsView: View {
         Dictionary(uniqueKeysWithValues: app.store.config.contestants.map { ($0.id, $0) })
     }
 
+    private var displayedEpisodes: [Episode] {
+        app.store.config.episodes
+            .filter { $0.id <= 2 }
+            .sorted(by: { $0.airDate > $1.airDate })
+    }
+
     var body: some View {
         NavigationStack {
-            List(app.store.config.episodes.sorted(by: { $0.airDate > $1.airDate })) { episode in
+            List(displayedEpisodes) { episode in
                 let result = app.store.resultsByEpisode[episode.id]
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {


### PR DESCRIPTION
## Summary
- limit the picks week picker to only the first two weeks and default the selection accordingly
- show only the first two weeks in the results list

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0809e99048329b4b2efe9e3143a13