### PR TITLE
Ensure LimitedMultiSelect handles duplicate contestants

### DIFF
--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -15,9 +15,18 @@ struct LimitedMultiSelect: View {
         GridItem(.adaptive(minimum: 96), spacing: 16, alignment: .top)
     ]
 
+    private var uniqueContestants: [Contestant] {
+        var seen = Set<String>()
+        return all.filter { contestant in
+            guard !seen.contains(contestant.id) else { return false }
+            seen.insert(contestant.id)
+            return true
+        }
+    }
+
     var body: some View {
         LazyVGrid(columns: columns, spacing: 16) {
-            ForEach(all) { contestant in
+            ForEach(uniqueContestants) { contestant in
                 let isSelected = selection.contains(contestant.id)
                 Button {
                     guard !disabled else { return }


### PR DESCRIPTION
## Summary
- filter the contestant list inside `LimitedMultiSelect` to ensure each identifier only appears once before rendering the grid

## Testing
- swift build *(fails: repository does not contain a Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68e092f02a0c832989043b2e3be5d408