### PR TITLE
Fix LimitedMultiSelect selection handling

### DIFF
--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -31,8 +31,9 @@ struct LimitedMultiSelect: View {
                 .filter { !$0.isEmpty }
         )
         LazyVGrid(columns: columns, spacing: 16) {
-            ForEach(uniqueContestants) { contestant in
-                let isSelected = selection.contains(contestant.id)
+            ForEach(uniqueContestants, id: \.id) { contestant in
+                let selectionId = contestant.id
+                let isSelected = normalizedSelection.contains(selectionId)
                 Button {
                     guard !disabled else { return }
                     if isSelected {


### PR DESCRIPTION
## Summary
- restore a defined selection identifier when iterating contestants
- ensure selection state uses normalized identifiers to match trimming logic

## Testing
- not run (not available in Linux container)

------
https://chatgpt.com/codex/tasks/task_e_68e09b5adb40832995d5fd970ac521b7