### PR TITLE
Fix ForEach data binding inference in LimitedMultiSelect

### DIFF
--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -31,7 +31,7 @@ struct LimitedMultiSelect: View {
                 .filter { !$0.isEmpty }
         )
         LazyVGrid(columns: columns, spacing: 16) {
-            ForEach(uniqueContestants) { contestant in
+            ForEach(uniqueContestants, id: \.id) { contestant in
                 let selectionId = contestant.id
                 let isSelected = normalizedSelection.contains(selectionId)
                 Button {


### PR DESCRIPTION
## Summary
- specify an explicit identifier key path for the ForEach in `LimitedMultiSelect` so SwiftUI picks the correct initializer

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e09d30ae748329810ff9b427e4df24