### PR TITLE
Fix LimitedMultiSelect ForEach initializer

### DIFF
--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -31,7 +31,7 @@ struct LimitedMultiSelect: View {
                 .filter { !$0.isEmpty }
         )
         LazyVGrid(columns: columns, spacing: 16) {
-            ForEach(uniqueContestants, id: \.id) { contestant in
+            ForEach(uniqueContestants) { contestant in
                 let selectionId = contestant.id
                 let isSelected = normalizedSelection.contains(selectionId)
                 Button {


### PR DESCRIPTION
## Summary
- use the Identifiable conformance of `Contestant` in `LimitedMultiSelect`'s `ForEach` to resolve build errors

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e09ecdaa3883299bd7d3b86062a2e1