### PR TITLE
Fix LimitedMultiSelect ForEach identifier

### DIFF
--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -34,11 +34,7 @@ struct LimitedMultiSelect: View {
 
     var body: some View {
         LazyVGrid(columns: columns, spacing: 16) {
-<<<<<<< Updated upstream
-            ForEach(uniqueContestants) { contestant in
-=======
-            ForEach(uniqueContestants, id: \<#Root#>.id) { contestant in
->>>>>>> Stashed changes
+            ForEach(uniqueContestants, id: \.id) { contestant in
                 let selectionId = contestant.id
                 let isSelected = normalizedSelection.contains(selectionId)
                 Button {


### PR DESCRIPTION
## Summary
- resolve merge conflict markers in `LimitedMultiSelect`
- restore `ForEach` to iterate over contestants using their identifier

## Testing
- not run (Xcode tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e0a15f3c648329983b955aa3d8cd5f