### PR TITLE
Remove redundant Body typealias from LimitedMultiSelect

### DIFF
--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -6,7 +6,6 @@ import SwiftUI
 /// contestant identifiers. The view enforces the `max` limit and optionally allows
 /// disabling user interaction.
 struct LimitedMultiSelect: View {
-    typealias Body = some View
     let all: [Contestant]
     @Binding var selection: Set<String>
     let max: Int


### PR DESCRIPTION
## Summary
- remove the redundant `Body` typealias from `LimitedMultiSelect`

## Testing
- swift build *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a55bee8883299bcb0922ce5a2b0e