### PR TITLE
Replace LimitedMultiSelect preview macro

### DIFF
--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -95,8 +95,10 @@ struct LimitedMultiSelect: View {
     }
 }
 
-#Preview("LimitedMultiSelect") {
-    LimitedMultiSelectPreview()
+struct LimitedMultiSelect_Previews: PreviewProvider {
+    static var previews: some View {
+        LimitedMultiSelectPreview()
+    }
 }
 
 private struct LimitedMultiSelectPreview: View {


### PR DESCRIPTION
## Summary
- replace the `#Preview` macro in `LimitedMultiSelect` with a `PreviewProvider` implementation to keep previews working on older toolchains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a7540b9c8329bc028f267145e68f