### PR TITLE
Avoid Set.removeAll ambiguity in LimitedMultiSelect

### DIFF
--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -42,9 +42,17 @@ struct LimitedMultiSelect: View {
                     if isSelected {
                         // Remove any persisted variants (e.g. with stray whitespace) so the
                         // selection stays normalized to a single identifier per contestant.
-                        selection.removeAll { $0.trimmingCharacters(in: .whitespacesAndNewlines) == selectionId }
+                        selection = Set(
+                            selection.filter { element in
+                                element.trimmingCharacters(in: .whitespacesAndNewlines) != selectionId
+                            }
+                        )
                     } else if normalizedSelection.count < max {
-                        selection.removeAll { $0.trimmingCharacters(in: .whitespacesAndNewlines) == selectionId }
+                        selection = Set(
+                            selection.filter { element in
+                                element.trimmingCharacters(in: .whitespacesAndNewlines) != selectionId
+                            }
+                        )
                         selection.insert(selectionId)
                     }
                 } label: {


### PR DESCRIPTION
## Summary
- replace the Set.removeAll(where:) calls in LimitedMultiSelect with explicit filtering to avoid the generic inference build error

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0aa96edb8832981fb17fa8992fea7