### PR TITLE
Fix LimitedMultiSelect selection state capture

### DIFF
--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -35,13 +35,15 @@ struct LimitedMultiSelect: View {
     var body: some View {
         LazyVGrid(columns: columns, spacing: 16) {
             ForEach(uniqueContestants, id: \.id) { contestant in
+                let currentlySelected = isSelected(contestant.id)
+
                 Button {
                     toggleSelection(for: contestant.id)
                 } label: {
                     selectionLabel(
                         for: contestant.id,
                         name: contestant.name,
-                        isCurrentlySelected: isSelected(contestant.id)
+                        isCurrentlySelected: currentlySelected
                     )
                 }
                 .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- compute the contestant's selection state once inside the grid loop
- pass the pre-evaluated Boolean into `selectionLabel`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0b5ea28f08329bc7d5e02cbf2c08b