### PR TITLE
Limit picks tab week selection to week one

### DIFF
--- a/survivus/Features/Picks/AllPicksView.swift
+++ b/survivus/Features/Picks/AllPicksView.swift
@@ -6,7 +6,7 @@ struct AllPicksView: View {
 
     private var weekOptions: [WeekOption] {
         app.store.config.episodes
-            .filter { $0.id <= 2 }
+            .filter { $0.id == 1 }
             .map { WeekOption(id: $0.id, title: $0.title) }
             .sorted { $0.id < $1.id }
     }


### PR DESCRIPTION
## Summary
- update the Picks tab week options to only include the first episode so week 2 is no longer selectable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e7dc7b4c832983ace9ca20d24f2b