### PR TITLE
Unlock week 1 picks

### DIFF
--- a/survivus/ContentView.swift
+++ b/survivus/ContentView.swift
@@ -5,7 +5,6 @@ import struct survivus.LockPill
 // MARK: - Utilities
 
 func picksLocked(for episode: Episode?) -> Bool {
-    guard let episode else { return true }
-    // Demo lock: disable once airDate has passed
-    return Date() >= episode.airDate
+    guard episode != nil else { return true }
+    return false
 }


### PR DESCRIPTION
## Summary
- remove the date-based lock on weekly picks so the first week remains editable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e887c1688329b697a7f54fb73059