### PR TITLE
Remove background from user picks cards

### DIFF
--- a/survivus/Features/Picks/AllPicksView.swift
+++ b/survivus/Features/Picks/AllPicksView.swift
@@ -142,10 +142,6 @@ private struct UserPicksCard: View {
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color(.secondarySystemBackground))
-        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- remove the rounded rectangle fill from the picks card so contestant grids no longer have a dark backdrop

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e0e97e14e48329a314f7a8d0bf7862