### PR TITLE
Adjust merge pick selection badge background

### DIFF
--- a/survivus/Shared/Components/LimitedMultiSelect.swift
+++ b/survivus/Shared/Components/LimitedMultiSelect.swift
@@ -96,7 +96,7 @@ struct LimitedMultiSelect: View {
                         .foregroundStyle(Color.accentColor, Color.white)
                         .background(
                             Circle()
-                                .fill(Color(.systemBackground))
+                                .fill(Color(.secondarySystemGroupedBackground))
                                 .frame(width: 24, height: 24)
                                 .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
                         )


### PR DESCRIPTION
## Summary
- use the grouped background color for the merge pick selection badge
- keep the badge shadow while avoiding the stark black background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0eb0e63a48329a899b1bd4fd9e275