### PR TITLE
Add background color to Picks user cards

### DIFF
--- a/survivus/Features/Picks/AllPicksView.swift
+++ b/survivus/Features/Picks/AllPicksView.swift
@@ -142,6 +142,10 @@ private struct UserPicksCard: View {
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- add a rounded rectangle background color to user pick cards in the Picks view for better separation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0f31ffe3083299b0d37a90eae66d1