### PR TITLE
Ensure season pick editors persist selections

### DIFF
--- a/survivus/Features/Picks/FinalThreePickEditor.swift
+++ b/survivus/Features/Picks/FinalThreePickEditor.swift
@@ -24,7 +24,11 @@ struct FinalThreePickEditor: View {
                     all: config.contestants,
                     selection: Binding(
                         get: { app.store.seasonPicks[userId]?.finalThreePicks ?? [] },
-                        set: { newValue in app.store.seasonPicks[userId]?.finalThreePicks = Set(newValue.prefix(maxSelection)) }
+                        set: { newValue in
+                            app.store.updateSeasonPicks(for: userId) { picks in
+                                picks.finalThreePicks = Set(newValue.prefix(maxSelection))
+                            }
+                        }
                     ),
                     max: maxSelection,
                     disabled: !afterMerge

--- a/survivus/Features/Picks/MergePickEditor.swift
+++ b/survivus/Features/Picks/MergePickEditor.swift
@@ -24,7 +24,11 @@ struct MergePickEditor: View {
                     all: config.contestants,
                     selection: Binding(
                         get: { app.store.seasonPicks[userId]?.mergePicks ?? [] },
-                        set: { newValue in app.store.seasonPicks[userId]?.mergePicks = Set(newValue.prefix(maxSelection)) }
+                        set: { newValue in
+                            app.store.updateSeasonPicks(for: userId) { picks in
+                                picks.mergePicks = Set(newValue.prefix(maxSelection))
+                            }
+                        }
                     ),
                     max: maxSelection,
                     disabled: disabled

--- a/survivus/Features/Picks/WinnerPickEditor.swift
+++ b/survivus/Features/Picks/WinnerPickEditor.swift
@@ -12,7 +12,11 @@ struct WinnerPickEditor: View {
             Section {
                 Picker("Winner", selection: Binding(
                     get: { app.store.seasonPicks[userId]?.winnerPick ?? "" },
-                    set: { app.store.seasonPicks[userId]?.winnerPick = $0.isEmpty ? nil : $0 }
+                    set: { newValue in
+                        app.store.updateSeasonPicks(for: userId) { picks in
+                            picks.winnerPick = newValue.isEmpty ? nil : newValue
+                        }
+                    }
                 )) {
                     Text("—").tag("")
                     ForEach(app.store.config.contestants) { contestant in

--- a/survivus/Services/Store/MemoryStore.swift
+++ b/survivus/Services/Store/MemoryStore.swift
@@ -31,4 +31,11 @@ final class MemoryStore: ObservableObject {
         weeklyPicks[picks.userId, default: [:]][picks.episodeId] = picks
         objectWillChange.send()
     }
+
+    func updateSeasonPicks(for userId: String, update: (inout SeasonPicks) -> Void) {
+        var picks = seasonPicks[userId] ?? SeasonPicks(userId: userId)
+        update(&picks)
+        seasonPicks[userId] = picks
+        objectWillChange.send()
+    }
 }


### PR DESCRIPTION
## Summary
- add a memory store helper that safely updates a user's season picks
- route season pick editors through the helper so selections persist back to the summary cards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0fc22f3008329956626c315cd207c