### PR TITLE
Update week picker to default to latest episode

### DIFF
--- a/survivus/Features/Picks/AllPicksView.swift
+++ b/survivus/Features/Picks/AllPicksView.swift
@@ -3,10 +3,10 @@ import SwiftUI
 struct AllPicksView: View {
     @EnvironmentObject var app: AppState
     @State private var selectedWeekId: Int = 1
+    @State private var hasInitializedWeekSelection = false
 
     private var weekOptions: [WeekOption] {
         app.store.config.episodes
-            .filter { $0.id == 1 }
             .map { WeekOption(id: $0.id, title: $0.title) }
             .sorted { $0.id < $1.id }
     }
@@ -40,9 +40,13 @@ struct AllPicksView: View {
                 .padding()
             }
             .onAppear {
-                if let firstWeek = weekOptions.first {
-                    selectedWeekId = firstWeek.id
+                guard !hasInitializedWeekSelection else { return }
+
+                if let latestWeek = weekOptions.max(by: { $0.id < $1.id }) {
+                    selectedWeekId = latestWeek.id
                 }
+
+                hasInitializedWeekSelection = true
             }
             .navigationTitle("Picks")
         }


### PR DESCRIPTION
## Summary
- show every episode in the week picker instead of filtering to the first entry
- default the week selection to the most recent episode when the view first appears

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0ff7ea4848329a25da9c3a31cb10d