### PR TITLE
Add border highlighting current user's picks card

### DIFF
--- a/survivus/Features/Picks/AllPicksView.swift
+++ b/survivus/Features/Picks/AllPicksView.swift
@@ -150,6 +150,15 @@ private struct UserPicksCard: View {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(Color(.secondarySystemBackground))
         )
+        .overlay {
+            if isCurrentUser {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(
+                        Color(red: 0.07, green: 0.19, blue: 0.42),
+                        lineWidth: 3
+                    )
+            }
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- add a dark blue border around the current user's picks card to make it stand out

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e10d5ccc1c83299073bde1b0a60eb9