### PR TITLE
Add Admin Room navigation link to picks view

### DIFF
--- a/survivus/Features/Picks/AdminRoomView.swift
+++ b/survivus/Features/Picks/AdminRoomView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct AdminRoomView: View {
+    var body: some View {
+        Text("Admin Room")
+            .font(.title)
+            .fontWeight(.semibold)
+            .padding()
+            .navigationTitle("Admin Room")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AdminRoomView()
+    }
+}

--- a/survivus/Features/Picks/PicksView.swift
+++ b/survivus/Features/Picks/PicksView.swift
@@ -68,12 +68,25 @@ struct PicksView: View {
 
     private var weeklySection: some View {
         Section("Weekly Picks") {
-            Picker("Episode", selection: Binding(
-                get: { selectedEpisode?.id ?? app.store.config.episodes.first?.id ?? 1 },
-                set: { newId in selectedEpisode = app.store.config.episodes.first(where: { $0.id == newId }) }
-            )) {
-                ForEach(app.store.config.episodes) { episode in
-                    Text(episode.title).tag(episode.id)
+            HStack(alignment: .firstTextBaseline) {
+                Picker("Episode", selection: Binding(
+                    get: { selectedEpisode?.id ?? app.store.config.episodes.first?.id ?? 1 },
+                    set: { newId in selectedEpisode = app.store.config.episodes.first(where: { $0.id == newId }) }
+                )) {
+                    ForEach(app.store.config.episodes) { episode in
+                        Text(episode.title).tag(episode.id)
+                    }
+                }
+
+                Spacer()
+
+                NavigationLink {
+                    AdminRoomView()
+                } label: {
+                    Image(systemName: "door.left.hand.open")
+                        .imageScale(.large)
+                        .padding(.leading, 8)
+                        .accessibilityLabel("Admin Room")
                 }
             }
 


### PR DESCRIPTION
## Summary
- add a navigation button with a door icon next to the weekly episode picker
- create an Admin Room destination view to display when the button is tapped

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e27a7c2adc8329874860c9b5ac0ed4