### PR TITLE
Create admin room layout sections

### DIFF
--- a/survivus/Features/Picks/AdminRoomView.swift
+++ b/survivus/Features/Picks/AdminRoomView.swift
@@ -2,11 +2,27 @@ import SwiftUI
 
 struct AdminRoomView: View {
     var body: some View {
-        Text("Admin Room")
-            .font(.title)
-            .fontWeight(.semibold)
-            .padding()
-            .navigationTitle("Admin Room")
+        Form {
+            Section {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Current Phase: Pre-merge")
+                    Text("Current Week: 2")
+                }
+            }
+
+            Section("Week") {
+                Button("Insert Results") {}
+                Button("Modify Previous Results") {}
+                Button("Start New Week") {}
+            }
+
+            Section("Phase") {
+                Button("Select Current Phase") {}
+                Button("Create New Phase") {}
+                Button("Remove Phase") {}
+            }
+        }
+        .navigationTitle("Admin Room")
     }
 }
 


### PR DESCRIPTION
## Summary
- add static text showing the current phase and week in the admin room
- add week and phase management sections with the requested action buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2871888688329b03a85cda6727336