### PR TITLE
Adjust create phase sheet layout for modal

### DIFF
--- a/survivus/Features/Picks/AdminRoomView.swift
+++ b/survivus/Features/Picks/AdminRoomView.swift
@@ -29,7 +29,8 @@ struct AdminRoomView: View {
         .navigationTitle("Admin Room")
         .sheet(isPresented: $isPresentingCreatePhase) {
             CreatePhaseSheet()
-                .presentationDetents([.medium, .large])
+                .presentationDetents([.fraction(0.8)])
+                .presentationCornerRadius(28)
         }
     }
 }
@@ -88,9 +89,13 @@ private struct CreatePhaseSheet: View {
                 } label: {
                     Text("Save")
                         .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
                 }
                 .buttonStyle(.borderedProminent)
-                .padding()
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .padding(.horizontal)
+                .padding(.top, 12)
+                .padding(.bottom, 24)
                 .background(Color(.systemGroupedBackground))
             }
         }


### PR DESCRIPTION
## Summary
- raise the Create Phase sheet to a fractional detent and round its corners more prominently
- adjust the Save button layout to sit higher with additional corner rounding for a softer appearance

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e378b1fef08329a98df1b3054fdbdc