### PR TITLE
Allow blank default for points per correct pick field

### DIFF
--- a/survivus/Features/Picks/AdminRoomView.swift
+++ b/survivus/Features/Picks/AdminRoomView.swift
@@ -47,7 +47,7 @@ private struct CreatePhaseSheet: View {
     @State private var phaseName = ""
     @State private var category = ""
     @State private var totalPicks = 1
-    @State private var pointsPerCorrectPick = 0
+    @State private var pointsPerCorrectPick: Int? = nil
     @State private var lockCategory = false
 
     var body: some View {


### PR DESCRIPTION
## Summary
- initialize the points per correct pick state as optional so the field starts blank and only shows the placeholder text

## Testing
- swift test *(fails: no Package.swift found)*

------
https://chatgpt.com/codex/tasks/task_e_68e37b85ba648329bd72b5724e511fb6