### PR TITLE
Fix ambiguous AdminPhase category initializer mapping

### DIFF
--- a/survivus/Features/Picks/AdminRoomView.swift
+++ b/survivus/Features/Picks/AdminRoomView.swift
@@ -155,7 +155,7 @@ private struct CreatePhaseSheet: View {
                     let newPhase = AdminPhase(
                         id: phase?.id ?? UUID(),
                         name: phaseNameToSave,
-                        categories: categories.map(AdminPhase.Category.init)
+                        categories: categories.map { AdminPhase.Category($0) }
                     )
                     onSave(newPhase)
                     dismiss()


### PR DESCRIPTION
## Summary
- resolve the ambiguous initializer reference when mapping phase categories

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e38a0486d08329b20fa160f5ed5b9e