### PR TITLE
Fix active badge accent style in admin phase list

### DIFF
--- a/survivus/Features/Picks/AdminRoomView.swift
+++ b/survivus/Features/Picks/AdminRoomView.swift
@@ -244,7 +244,7 @@ private struct PhaseRow: View {
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
                         .background(Color.accentColor.opacity(0.15))
-                        .foregroundStyle(.accent)
+                        .foregroundStyle(Color.accentColor)
                         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                 }
             }


### PR DESCRIPTION
## Summary
- replace the deprecated `.foregroundStyle(.accent)` call with `.foregroundStyle(Color.accentColor)` in the admin phase row badge

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e38b31992883299190dbd33a3299cd