### PR TITLE
Fix AllPicksView week picker binding

### DIFF
--- a/survivus/Features/Picks/AllPicksView.swift
+++ b/survivus/Features/Picks/AllPicksView.swift
@@ -52,12 +52,13 @@ struct AllPicksView: View {
                 .foregroundStyle(.secondary)
             
             HStack(alignment: .firstTextBaseline) {
-                Picker<Text, <#SelectionValue: Hashable#>, ForEach<[WeekOption], WeekSelection, some View>>("Week", selection: $selectedWeekId) {
+                Picker("Week", selection: $selectedWeek) {
                     ForEach(weekOptions) { option in
                         Text(option.title)
-                            .tag(option.id)
+                            .tag(option.selection)
                     }
-                }.pickerStyle(.menu)
+                }
+                .pickerStyle(.menu)
                 
                 Spacer()
                 


### PR DESCRIPTION
## Summary
- replace placeholder generic picker signature in AllPicksView with concrete WeekSelection binding
- tag picker entries with the stored WeekSelection value to restore menu functionality

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4f37f1aa88329b757db46074449c4