### PR TITLE
Limit week picker options to started episodes

### DIFF
--- a/survivus/Features/Picks/AllPicksView.swift
+++ b/survivus/Features/Picks/AllPicksView.swift
@@ -5,7 +5,9 @@ struct AllPicksView: View {
     @State private var selectedWeek: WeekSelection = .none
 
     private var weekOptions: [WeekOption] {
+        let now = Date()
         let episodeOptions = app.store.config.episodes
+            .filter { $0.airDate <= now }
             .sorted { $0.id < $1.id }
             .map { WeekOption(selection: .week($0.id), title: $0.title) }
         return [WeekOption(selection: .none, title: "None")] + episodeOptions


### PR DESCRIPTION
## Summary
- hide week options in the Picks tab until an episode's air date has passed so no weeks appear before they start

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4f50e10588329a4f9be6d725697f7