### PR TITLE
Display current week as None when no results exist

### DIFF
--- a/survivus/Features/Picks/AdminRoomView.swift
+++ b/survivus/Features/Picks/AdminRoomView.swift
@@ -14,7 +14,7 @@ struct AdminRoomView: View {
             Section {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Current Phase: \(currentPhase?.name ?? "None")")
-                    Text("Current Week: 2")
+                    Text("Current Week: \(currentWeekTitle)")
                 }
             }
 
@@ -94,6 +94,18 @@ struct AdminRoomView: View {
 }
 
 private extension AdminRoomView {
+    var currentWeekTitle: String {
+        guard let weekId = app.store.results.map(\.id).max() else {
+            return "None"
+        }
+
+        if let episode = app.store.config.episodes.first(where: { $0.id == weekId }) {
+            return episode.title
+        }
+
+        return "Week \(weekId)"
+    }
+
     var canInsertResults: Bool {
         guard let phase = currentPhase else { return false }
         return !phase.categories.isEmpty


### PR DESCRIPTION
## Summary
- derive the admin room current week label from the latest recorded results
- fall back to "None" when the season has not started yet

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4fd5031c08329aa21866da231603f