### PR TITLE
Disable admin room buttons when no phases exist

### DIFF
--- a/survivus/Features/Picks/AdminRoomView.swift
+++ b/survivus/Features/Picks/AdminRoomView.swift
@@ -24,15 +24,18 @@ struct AdminRoomView: View {
                         phaseForInsertingResults = phase
                     }
                 }
-                .disabled(!canInsertResults)
+                .disabled(!canInsertResults || !hasPhases)
                 Button("Modify Previous Results") {}
+                .disabled(!hasPhases)
                 Button("Start New Week") {}
+                .disabled(!hasPhases)
             }
 
             Section("Phase") {
                 Button("Select Current Phase") {
                     isPresentingSelectPhase = true
                 }
+                .disabled(!hasPhases)
                 Button("Create New Phase") {
                     phaseBeingEdited = nil
                     isPresentingCreatePhase = true
@@ -109,6 +112,10 @@ private extension AdminRoomView {
     var canInsertResults: Bool {
         guard let phase = currentPhase else { return false }
         return !phase.categories.isEmpty
+    }
+
+    var hasPhases: Bool {
+        !phases.isEmpty
     }
 }
 


### PR DESCRIPTION
## Summary
- disable administrative actions when there are no phases so only the Create New Phase button remains active
- add a helper flag to simplify button state checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5047d8ae08329bf5f1001552e8c40