### PR TITLE
Disable starting new week until results submitted

### DIFF
--- a/survivus/Features/Picks/AdminRoomView.swift
+++ b/survivus/Features/Picks/AdminRoomView.swift
@@ -33,7 +33,7 @@ struct AdminRoomView: View {
                     selectedPhaseForNewWeekID = currentPhase?.id ?? phases.first?.id
                     isPresentingStartWeek = true
                 }
-                .disabled(!hasPhases)
+                .disabled(!canStartNewWeek)
             }
 
             Section("Phase") {
@@ -131,6 +131,18 @@ private extension AdminRoomView {
 
     var hasPhases: Bool {
         !phases.isEmpty
+    }
+
+    var canStartNewWeek: Bool {
+        hasPhases && hasSubmittedResultsForCurrentWeek
+    }
+
+    var hasSubmittedResultsForCurrentWeek: Bool {
+        guard let latestResult = app.store.results.max(by: { $0.id < $1.id }) else {
+            return true
+        }
+
+        return !latestResult.immunityWinners.isEmpty || !latestResult.votedOut.isEmpty
     }
 
     func startNewWeek(activating phase: AdminPhase) {


### PR DESCRIPTION
## Summary
- disable the Start New Week button unless results have been entered for the current week
- add helpers to determine whether the latest week has submitted results before enabling the control

## Testing
- not run (not supported)


------
https://chatgpt.com/codex/tasks/task_e_68e50d56cc648329948866c5da826de0