### PR TITLE
Forward MemoryStore updates through AppState

### DIFF
--- a/survivus/Services/AppState.swift
+++ b/survivus/Services/AppState.swift
@@ -6,10 +6,14 @@ final class AppState: ObservableObject {
     // TODO: When a Core Data-backed persistence layer is introduced, inject a persistent store
     // implementation here (likely created from a `PersistenceController`) instead of the
     // in-memory mock `MemoryStore` so user progress survives app restarts.
-    @Published var store: MemoryStore
+    @Published var store: MemoryStore {
+        didSet { subscribeToStoreChanges() }
+    }
     @Published var currentUserId: String
     @Published var phases: [PickPhase]
     @Published var activePhaseId: PickPhase.ID?
+
+    private var cancellables: Set<AnyCancellable> = []
 
     init() {
         let config = SeasonConfig.mock()
@@ -24,6 +28,7 @@ final class AppState: ObservableObject {
         self.currentUserId = users.first!.id
         self.phases = PickPhase.preconfigured
         self.activePhaseId = phases.first?.id
+        subscribeToStoreChanges()
     }
 
     var scoring: ScoringEngine {
@@ -33,5 +38,16 @@ final class AppState: ObservableObject {
     var activePhase: PickPhase? {
         guard let activePhaseId else { return nil }
         return phases.first(where: { $0.id == activePhaseId })
+    }
+
+    private func subscribeToStoreChanges() {
+        cancellables.removeAll()
+
+        store.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
## Summary
- forward `MemoryStore` publisher events through `AppState` so SwiftUI screens refresh when picks change
- resubscribe to store updates if the backing store instance is replaced

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e52660ea8483298012c06a11ff2c5c