### PR TITLE
Gray out avatars for eliminated contestants

### DIFF
--- a/survivus/Services/AppState.swift
+++ b/survivus/Services/AppState.swift
@@ -35,6 +35,10 @@ final class AppState: ObservableObject {
         ScoringEngine(config: store.config, resultsByEpisode: store.resultsByEpisode)
     }
 
+    var votedOutContestantIDs: Set<String> {
+        Set(store.results.flatMap(\.votedOut))
+    }
+
     var activePhase: PickPhase? {
         guard let activePhaseId else { return nil }
         return phases.first(where: { $0.id == activePhaseId })

--- a/survivus/Shared/Components/ContestantIdentityViews.swift
+++ b/survivus/Shared/Components/ContestantIdentityViews.swift
@@ -5,8 +5,12 @@ import UIKit
 
 /// Displays a contestant's circular avatar using the image that matches the contestant identifier.
 struct ContestantAvatar: View {
+    @Environment(\.votedOutContestantIDs) private var votedOutContestantIDs
+
     let imageName: String
     var size: CGFloat = 28
+
+    private var isVotedOut: Bool { votedOutContestantIDs.contains(imageName) }
 
     var body: some View {
         Group {
@@ -24,6 +28,8 @@ struct ContestantAvatar: View {
         }
         .frame(width: size, height: size)
         .clipShape(Circle())
+        .grayscale(isVotedOut ? 1 : 0)
+        .opacity(isVotedOut ? 0.45 : 1)
         .accessibilityHidden(true)
     }
 

--- a/survivus/Shared/Environment/VotedOutContestantEnvironment.swift
+++ b/survivus/Shared/Environment/VotedOutContestantEnvironment.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct VotedOutContestantIDsKey: EnvironmentKey {
+    static let defaultValue: Set<String> = []
+}
+
+extension EnvironmentValues {
+    var votedOutContestantIDs: Set<String> {
+        get { self[VotedOutContestantIDsKey.self] }
+        set { self[VotedOutContestantIDsKey.self] = newValue }
+    }
+}

--- a/survivus/survivusApp.swift
+++ b/survivus/survivusApp.swift
@@ -17,6 +17,7 @@ struct SurvivusApp: App {
                     .environmentObject(app)
                     .tabItem { Label("Table", systemImage: "tablecells") }
             }
+            .environment(\.votedOutContestantIDs, app.votedOutContestantIDs)
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose a computed set of voted-out contestants from the app state
- inject the voted-out contestant IDs into the SwiftUI environment for all tabs
- gray out contestant avatars automatically whenever their ID appears in the voted-out list

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e5462971f88329ad5c3411f3d518c2