### PR TITLE
Fix weekly pick limits using active phase categories

### DIFF
--- a/survivus/Features/Picks/AdminRoomView.swift
+++ b/survivus/Features/Picks/AdminRoomView.swift
@@ -720,18 +720,3 @@ private struct PhaseRow: View {
         .padding(.vertical, 8)
     }
 }
-
-private extension PickPhase.Category {
-    var normalizedName: String {
-        name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    }
-
-    var matchesImmunityCategory: Bool {
-        normalizedName.contains("immunity")
-    }
-
-    var matchesVotedOutCategory: Bool {
-        normalizedName.contains("voted")
-    }
-}
-

--- a/survivus/Features/Picks/WeeklyPickEditor.swift
+++ b/survivus/Features/Picks/WeeklyPickEditor.swift
@@ -23,7 +23,7 @@ struct WeeklyPickEditor: View {
         let userId = app.currentUserId
         let phase = app.scoring.phase(for: episode)
         let caps = (phase == .preMerge) ? config.weeklyPickCapsPreMerge : config.weeklyPickCapsPostMerge
-        let limit = selectionLimit(for: panel, caps: caps)
+        let limit = phaseCategoryLimit(for: panel) ?? selectionLimit(for: panel, caps: caps)
         let locked = picksLocked(for: episode)
 
         ScrollView {
@@ -93,6 +93,24 @@ struct WeeklyPickEditor: View {
         case .immunity:
             return caps.immunity ?? 3
         }
+    }
+
+    private func phaseCategoryLimit(for panel: WeeklyPickPanel) -> Int? {
+        guard let categories = app.activePhase?.categories else { return nil }
+
+        let matchingCategory: PickPhase.Category?
+
+        switch panel {
+        case .remain:
+            matchingCategory = categories.first(where: { $0.matchesRemainCategory })
+        case .votedOut:
+            matchingCategory = categories.first(where: { $0.matchesVotedOutCategory })
+        case .immunity:
+            matchingCategory = categories.first(where: { $0.matchesImmunityCategory })
+        }
+
+        guard let total = matchingCategory?.totalPicks, total > 0 else { return nil }
+        return total
     }
 
     private func navigationTitle(for panel: WeeklyPickPanel) -> String {

--- a/survivus/Models/PickPhase+CategoryMatching.swift
+++ b/survivus/Models/PickPhase+CategoryMatching.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+extension PickPhase.Category {
+    var normalizedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    var matchesImmunityCategory: Bool {
+        normalizedName.contains("immunity")
+    }
+
+    var matchesVotedOutCategory: Bool {
+        normalizedName.contains("voted")
+    }
+
+    var matchesRemainCategory: Bool {
+        normalizedName.contains("remain") || normalizedName.contains("safe")
+    }
+}


### PR DESCRIPTION
## Summary
- ensure weekly pick editing respects the total pick limits defined by the active phase categories
- centralize category matching helpers so pick editors share the same logic as the admin view

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e6552f68508329816da5167dd89d0c